### PR TITLE
fix: config being mutated across executions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "changeme",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "changeme",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.5",
         "@mantine/code-highlight": "^8.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "changeme",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Browser automation made simple. Inject code, run scripts, and automate tasks with a user-friendly interface.",
   "type": "module",
   "scripts": {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -56,3 +56,7 @@ export const getElement = (
   }
   return null;
 };
+
+export const deepCopy = <T>(obj: T): T => {
+  return JSON.parse(JSON.stringify(obj));
+};


### PR DESCRIPTION
We need to do a deep copy of the config to avoid the config being mutated across executions, causing interpolated variables to not work after the first execution.