### PR TITLE
fix: parallel running user scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "changeme",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "changeme",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.5",
         "@mantine/code-highlight": "^8.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "changeme",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Browser automation made simple. Inject code, run scripts, and automate tasks with a user-friendly interface.",
   "type": "module",
   "scripts": {

--- a/src/services/userScriptManager.ts
+++ b/src/services/userScriptManager.ts
@@ -257,28 +257,10 @@ export class UserScriptManager {
         const Return = function(data) {
           resolve({ success: true, data: data });
         };
-
-        try {
-          ${userScript}
-
-          // If no Return was called, auto-resolve
-          resolve({ success: true, data: null });
-        } catch (evalError) {
-          // Check if this is a CSP error
-          const errorMessage = evalError?.message || evalError?.toString() || '';
-          const isCSPError = errorMessage.includes('Content-Security-Policy') ||
-                           errorMessage.includes('unsafe-eval') ||
-                           errorMessage.includes('script-src') ||
-                           errorMessage.includes('CSP');
-
-          const finalError = isCSPError ? 'CSP_VIOLATION: ' + errorMessage : errorMessage;
-
-          resolve({ success: false, error: finalError });
-        }
-      }).catch(error => ({
-        success: false,
-        error: error.message || error.toString()
-      }));
+        ${userScript}
+        // If no Return was called, auto-resolve
+        resolve({ success: true, data: null });
+      }).catch(error => ({success: false, error: error.message || error.toString()}));
 
       // Send the result back to the background script
       window.postMessage({


### PR DESCRIPTION
- User promise-based approach for the `Return` custom method.
- Keep track of nodes processing so the workflow executor waits for all nodes to be processed before terminating