### PR TITLE
fix/refactor: improve spa navigation and simplify content script lifecycle

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -66,6 +66,14 @@ chatbot.init();
 ApiClient.startBackgroundProxy();
 
 const workflowEngine = new BackgroundWorkflowEngine();
+
+browser.tabs.onRemoved.addListener((tabId: number) => {
+  workflowEngine.clearTab(tabId);
+  if (httpListener) {
+    httpListener.unregisterTriggers(tabId);
+  }
+});
+
 browser.runtime.onMessage.addListener(
   (message: CustomMessage, sender: any, sendResponse: (response?: any) => void) => {
   switch (message.type) {
@@ -129,6 +137,17 @@ browser.runtime.onMessage.addListener(
       return true;
     }
 
+    case "UNREGISTER_HTTP_TRIGGER": {
+      if (httpListener) {
+        httpListener.unregisterTrigger(
+          sender.tab.id,
+          message.data.workflowId,
+          message.data.triggerNodeId,
+        );
+      }
+      return;
+    }
+
     case WorkflowCommandType.CLEAN_HTTP_TRIGGERS:
       if (httpListener) {
         httpListener.unregisterTriggers(sender.tab.id);
@@ -139,6 +158,34 @@ browser.runtime.onMessage.addListener(
 );
 
 workflowEngine.initialize().then(() => {
+  browser.webNavigation.onCommitted.addListener(
+    (details: {
+      tabId: number;
+      frameId: number;
+      transitionType?: string;
+      transitionQualifiers?: string[];
+    }) => {
+      if (details.frameId !== 0) return;
+
+      // Only clear tab state for cross-document navigations (typed URL,
+      // link click, reload, etc.).  SPA-style back/forward navigations
+      // keep the content script alive, so clearing state would kill
+      // in-flight executors.  Those navigations are handled by
+      // onHistoryStateUpdated → onNewUrl which does its own
+      // delta-based cleanup.
+      const isBackForward =
+        details.transitionQualifiers?.includes("forward_back");
+
+      if (!isBackForward) {
+        workflowEngine.clearTab(details.tabId);
+        if (httpListener) {
+          httpListener.unregisterTriggers(details.tabId);
+        }
+      }
+    },
+    { url: [{ schemes: ["http", "https"] }] },
+  );
+
   browser.webNavigation.onCompleted.addListener(
     (details: { url: string; tabId: number; frameId: number }) => {
       if (details.frameId === 0) {
@@ -151,6 +198,7 @@ workflowEngine.initialize().then(() => {
   browser.webNavigation.onHistoryStateUpdated.addListener(
     (details: { url: string; tabId: number; frameId: number }) => {
       if (details.frameId === 0) {
+        workflowEngine.clearTab(details.tabId);
         workflowEngine.onNewUrl(details.tabId, details.url);
       }
     },

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -12,6 +12,7 @@ import { WorkflowSyncer } from "@/services/workflowSyncer";
 import { ChatbotService } from "../services/chatbot";
 
 let httpListener: HttpListenerWebRequest | null = null;
+
 if (browser.webRequest.onBeforeRequest) {
   try {
     httpListener = HttpListenerWebRequest.getInstance();
@@ -75,85 +76,89 @@ browser.tabs.onRemoved.addListener((tabId: number) => {
 });
 
 browser.runtime.onMessage.addListener(
-  (message: CustomMessage, sender: any, sendResponse: (response?: any) => void) => {
-  switch (message.type) {
-    case WorkflowCommandType.TRIGGER_FIRED: {
-      const tabId = sender.tab.id;
+  (
+    message: CustomMessage,
+    sender: any,
+    sendResponse: (response?: any) => void,
+  ) => {
+    switch (message.type) {
+      case WorkflowCommandType.TRIGGER_FIRED: {
+        const tabId = sender.tab.id;
 
-          const response = message.data as TriggerFiredCommand;
-          const url = response.url;
-          const pageTitle = sender.tab?.title || "";
-          const workflowId = response.workflowId;
-          const triggerNodeId = response.triggerNodeId;
-      const triggerData = response.data || {};
-      const config = response.config || {};
-      const duration = response.duration || 0;
-      workflowEngine.dispatchExecutor({
-            url,
-            pageTitle,
-            tabId,
-            workflowId,
-            triggerNodeId,
-        triggerData,
-        config,
-        duration,
-      });
-      return;
-    }
-    case "REGISTER_HTTP_TRIGGER": {
-      console.debug("Background: Registering HTTP trigger", message);
-
-      if (!httpListener) {
-        console.error(
-          "Background: Cannot register HTTP trigger - httpListener not available",
-        );
-        sendResponse({ success: false, error: "httpListener not available" });
-        return true;
-      }
-
-      const triggerCallback = async (data: any) => {
-        console.debug("HTTP trigger fired:", {
-          tabId: sender.tab.id,
-          workflowId: message.data.workflowId,
-          triggerNodeId: message.data.triggerNodeId,
-          data,
+        const response = message.data as TriggerFiredCommand;
+        const url = response.url;
+        const pageTitle = sender.tab?.title || "";
+        const workflowId = response.workflowId;
+        const triggerNodeId = response.triggerNodeId;
+        const triggerData = response.data || {};
+        const config = response.config || {};
+        const duration = response.duration || 0;
+        workflowEngine.dispatchExecutor({
+          url,
+          pageTitle,
+          tabId,
+          workflowId,
+          triggerNodeId,
+          triggerData,
+          config,
+          duration,
         });
-        sendMessageToContentScript(sender.tab.id, "HTTP_TRIGGER_FIRED", {
-          workflowId: message.data.workflowId,
-          triggerNodeId: message.data.triggerNodeId,
-          data,
-        }).catch(() => {});
-      };
+        return;
+      }
+      case "REGISTER_HTTP_TRIGGER": {
+        console.debug("Background: Registering HTTP trigger", message);
 
-      httpListener.registerTrigger(
-        sender.tab.id,
-        message.data.workflowId,
-        message.data.triggerNodeId,
-        message.data.urlPattern,
-        message.data.method,
-        triggerCallback,
-      );
-      sendResponse({ success: true });
-      return true;
-    }
+        if (!httpListener) {
+          console.error(
+            "Background: Cannot register HTTP trigger - httpListener not available",
+          );
+          sendResponse({ success: false, error: "httpListener not available" });
+          return true;
+        }
 
-    case "UNREGISTER_HTTP_TRIGGER": {
-      if (httpListener) {
-        httpListener.unregisterTrigger(
+        const triggerCallback = async (data: any) => {
+          console.debug("HTTP trigger fired:", {
+            tabId: sender.tab.id,
+            workflowId: message.data.workflowId,
+            triggerNodeId: message.data.triggerNodeId,
+            data,
+          });
+          sendMessageToContentScript(sender.tab.id, "HTTP_TRIGGER_FIRED", {
+            workflowId: message.data.workflowId,
+            triggerNodeId: message.data.triggerNodeId,
+            data,
+          }).catch(() => {});
+        };
+
+        httpListener.registerTrigger(
           sender.tab.id,
           message.data.workflowId,
           message.data.triggerNodeId,
+          message.data.urlPattern,
+          message.data.method,
+          triggerCallback,
         );
+        sendResponse({ success: true });
+        return true;
       }
-      return;
-    }
 
-    case WorkflowCommandType.CLEAN_HTTP_TRIGGERS:
-      if (httpListener) {
-        httpListener.unregisterTriggers(sender.tab.id);
+      case "UNREGISTER_HTTP_TRIGGER": {
+        if (httpListener) {
+          httpListener.unregisterTrigger(
+            sender.tab.id,
+            message.data.workflowId,
+            message.data.triggerNodeId,
+          );
+        }
+        return;
       }
-      return;
-  }
+
+      case WorkflowCommandType.CLEAN_HTTP_TRIGGERS:
+        if (httpListener) {
+          httpListener.unregisterTriggers(sender.tab.id);
+        }
+        return;
+    }
   },
 );
 
@@ -189,7 +194,9 @@ workflowEngine.initialize().then(() => {
   browser.webNavigation.onCompleted.addListener(
     (details: { url: string; tabId: number; frameId: number }) => {
       if (details.frameId === 0) {
-        workflowEngine.onNewUrl(details.tabId, details.url);
+        workflowEngine.onNewUrl(details.tabId, details.url).catch((error) => {
+          console.warn("Failed to handle completed navigation:", error);
+        });
       }
     },
     { url: [{ schemes: ["http", "https"] }] },
@@ -198,8 +205,9 @@ workflowEngine.initialize().then(() => {
   browser.webNavigation.onHistoryStateUpdated.addListener(
     (details: { url: string; tabId: number; frameId: number }) => {
       if (details.frameId === 0) {
-        workflowEngine.clearTab(details.tabId);
-        workflowEngine.onNewUrl(details.tabId, details.url);
+        workflowEngine.onNewUrl(details.tabId, details.url).catch((error) => {
+          console.warn("Failed to handle history state update:", error);
+        });
       }
     },
     { url: [{ schemes: ["http", "https"] }] },

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -116,27 +116,29 @@ browser.runtime.onMessage.addListener(
           return true;
         }
 
-        const triggerCallback = async (data: any) => {
-          console.debug("HTTP trigger fired:", {
-            tabId: sender.tab.id,
-            workflowId: message.data.workflowId,
-            triggerNodeId: message.data.triggerNodeId,
-            data,
-          });
-          sendMessageToContentScript(sender.tab.id, "HTTP_TRIGGER_FIRED", {
-            workflowId: message.data.workflowId,
-            triggerNodeId: message.data.triggerNodeId,
-            data,
-          }).catch(() => {});
-        };
-
         httpListener.registerTrigger(
           sender.tab.id,
           message.data.workflowId,
           message.data.triggerNodeId,
           message.data.urlPattern,
           message.data.method,
-          triggerCallback,
+          async (data: any) => {
+            console.debug("HTTP trigger fired:", {
+              tabId: sender.tab.id,
+              workflowId: message.data.workflowId,
+              triggerNodeId: message.data.triggerNodeId,
+              data,
+            });
+            await sendMessageToContentScript(
+              sender.tab.id,
+              "HTTP_TRIGGER_FIRED",
+              {
+                workflowId: message.data.workflowId,
+                triggerNodeId: message.data.triggerNodeId,
+                data,
+              },
+            ).catch(() => {});
+          },
         );
         sendResponse({ success: true });
         return true;

--- a/src/components/ai/ToolInvocationCard.tsx
+++ b/src/components/ai/ToolInvocationCard.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Collapse,
   Group,
+  Loader,
   Paper,
   rem,
   Stack,
@@ -14,7 +15,6 @@ import {
   IconAlertCircle,
   IconChevronDown,
   IconCheck,
-  IconClockHour4,
   IconPlayerPause,
   IconTool,
 } from "@tabler/icons-react";
@@ -36,7 +36,7 @@ type ToolInvocationCardProps = {
 type ToolStateMeta = {
   label: string;
   color: string;
-  icon: typeof IconTool;
+  icon: typeof IconTool | typeof Loader;
 };
 
 function getToolName(type: string) {
@@ -63,7 +63,7 @@ function getStateMeta(state?: string): ToolStateMeta {
     case "input-available":
     case "input-streaming":
     default:
-      return { label: "Running", color: "blue", icon: IconClockHour4 };
+      return { label: "Running", color: "blue", icon: Loader };
   }
 }
 

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -13,7 +13,6 @@ import { WorkflowScriptMessage } from "@/services/userScriptManager";
 import {
   ActionCommand,
   CleanupWorkflowTriggersCommand,
-  ReadinessResponse,
   StatusMessage,
   TriggerCommand,
   TriggerFiredCommand,
@@ -35,9 +34,7 @@ if ((window as any).houdinExtensionInitialized) {
 } else {
   (window as any).houdinExtensionInitialized = true;
 
-  let contentInjector: ContentInjector;
-  let isFullyInitialized = false;
-  let isInitializing = false;
+  const contentInjector = new ContentInjector();
   let lastSelectedElement: SelectedElementContext | undefined;
 
   interface ElementSelectedDetail {
@@ -52,60 +49,21 @@ if ((window as any).houdinExtensionInitialized) {
     };
   }
 
-  const initMinimalContentScript = () => {
-    console.debug("Houdin extension minimal initialization");
-
-    // Set up readiness check listener
-    setupReadinessCheckListener();
-    setupElementSelectionBridge();
-  };
-
-  const initFullContentScript = () => {
-    if (isFullyInitialized || isInitializing) return;
-    isInitializing = true;
-
-    console.debug("Houdin extension full initialization");
-
-    // Initialize content injector
-    contentInjector = new ContentInjector();
-    contentInjector.initialize();
-
-    // Set up notification message listener
-    setupNotificationBridge();
-
-    // Set up workflow script bridge (only needed when workflows are active)
-    setupWorkflowScriptBridge();
-
-    // Set up workflow engine bridge
-    setupBackgroundEngineBridge();
-
-    isFullyInitialized = true;
-    isInitializing = false;
-  };
-
-  const setupReadinessCheckListener = () => {
+  const setupPageContextBridge = () => {
     browser.runtime.onMessage.addListener(
       (
         message: CustomMessage<any>,
         _sender,
-        sendResponse: (response: ReadinessResponse) => void,
+        sendResponse: (response: {
+          ready: boolean;
+          data?: PageContextSnapshot;
+        }) => void,
       ) => {
         if (message.type === "GET_PAGE_CONTEXT") {
           sendResponse({ ready: true, data: getPageContextSnapshot() });
           return true;
         }
 
-        if (message.type === WorkflowCommandType.CHECK_READINESS) {
-          console.log(isFullyInitialized);
-          if (isFullyInitialized) {
-            contentInjector?.ensureInitialized();
-          } else {
-            initFullContentScript();
-          }
-
-          sendResponse({ ready: true });
-          return true; // Indicate async response
-        }
         return; // Let other listeners handle other messages
       },
     );
@@ -436,11 +394,23 @@ if ((window as any).houdinExtensionInitialized) {
     );
   };
 
-  // Initialize minimal content script when DOM is ready
+  const initializeContentScript = () => {
+    console.debug("Houdin extension initialization");
+    contentInjector.initialize();
+    setupPageContextBridge();
+    setupElementSelectionBridge();
+    setupNotificationBridge();
+    setupWorkflowScriptBridge();
+    setupBackgroundEngineBridge();
+  };
+
+  // Initialize content script when DOM is ready
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", initMinimalContentScript);
+    document.addEventListener("DOMContentLoaded", initializeContentScript, {
+      once: true,
+    });
   } else {
-    initMinimalContentScript();
+    initializeContentScript();
   }
 
   const cleanUpHttpTriggers = () => {
@@ -450,6 +420,5 @@ if ((window as any).houdinExtensionInitialized) {
   // Cleanup on page unload
   window.addEventListener("beforeunload", () => {
     cleanUpHttpTriggers();
-    (window as any).houdinExtensionInitialized = false;
   });
 }

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -12,6 +12,7 @@ import { TriggerRegistry } from "@/services/triggerRegistry";
 import { WorkflowScriptMessage } from "@/services/userScriptManager";
 import {
   ActionCommand,
+  CleanupWorkflowTriggersCommand,
   ReadinessResponse,
   StatusMessage,
   TriggerCommand,
@@ -95,7 +96,10 @@ if ((window as any).houdinExtensionInitialized) {
         }
 
         if (message.type === WorkflowCommandType.CHECK_READINESS) {
-          if (!isFullyInitialized) {
+          console.log(isFullyInitialized);
+          if (isFullyInitialized) {
+            contentInjector?.ensureInitialized();
+          } else {
             initFullContentScript();
           }
 
@@ -167,7 +171,11 @@ if ((window as any).houdinExtensionInitialized) {
     }
 
     const active = document.activeElement as HTMLElement | null;
-    if (!active || active === document.body || active === document.documentElement) {
+    if (
+      !active ||
+      active === document.body ||
+      active === document.documentElement
+    ) {
       return undefined;
     }
 
@@ -298,13 +306,34 @@ if ((window as any).houdinExtensionInitialized) {
         switch (message.type) {
           case WorkflowCommandType.CLEANUP_TRIGGERS: {
             const triggerRegistry = TriggerRegistry.getInstance();
-            triggerRegistry.cleanupAll().then(() => {
-              sendResponse({ success: true });
-            }).catch((error) => {
-              console.error("Failed to cleanup triggers:", error);
-              sendResponse({ success: false, error: String(error) });
-            });
+            triggerRegistry
+              .cleanupAll()
+              .then(() => {
+                sendResponse({ success: true });
+              })
+              .catch((error) => {
+                console.error("Failed to cleanup triggers:", error);
+                sendResponse({ success: false, error: String(error) });
+              });
             return true; // async response
+          }
+          case WorkflowCommandType.CLEANUP_WORKFLOW_TRIGGERS: {
+            const cleanupCommand =
+              message.data as unknown as CleanupWorkflowTriggersCommand;
+            const triggerRegistry = TriggerRegistry.getInstance();
+            Promise.all(
+              cleanupCommand.workflowIds.map((workflowId) =>
+                triggerRegistry.cleanupByWorkflow(workflowId),
+              ),
+            )
+              .then(() => {
+                sendResponse({ success: true });
+              })
+              .catch((error) => {
+                console.error("Failed to cleanup workflow triggers:", error);
+                sendResponse({ success: false, error: String(error) });
+              });
+            return true;
           }
           case WorkflowCommandType.INIT_TRIGGER:
             const initTriggerCommand = message.data as TriggerCommand;
@@ -420,9 +449,6 @@ if ((window as any).houdinExtensionInitialized) {
 
   // Cleanup on page unload
   window.addEventListener("beforeunload", () => {
-    if (contentInjector) {
-      contentInjector.destroy();
-    }
     cleanUpHttpTriggers();
     (window as any).houdinExtensionInitialized = false;
   });

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -6,9 +6,6 @@ const RECEIVING_END_ERRORS = [
   "Receiving end does not exist",
 ];
 
-const delay = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
-
 const isReceivingEndError = (error: unknown): boolean => {
   const message = error instanceof Error ? error.message : String(error);
   return RECEIVING_END_ERRORS.some((value) => message.includes(value));
@@ -65,7 +62,7 @@ export const sendMessageToContentScript = async <T>(
         type,
         attempt,
       });
-      await delay(retryDelayMs);
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
     }
   }
 };

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,5 +1,19 @@
 import browser from "@/services/browser";
 
+const RECEIVING_END_ERRORS = [
+  "Could not establish connection. Receiving end does not exist.",
+  "Could not establish connection",
+  "Receiving end does not exist",
+];
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const isReceivingEndError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  return RECEIVING_END_ERRORS.some((value) => message.includes(value));
+};
+
 export const sendMessageToBackground = async <T>(
   type: string,
   data?: T,
@@ -30,10 +44,28 @@ export const sendMessageToContentScript = async <T>(
     type,
     data,
   });
-  return await browser.tabs
-    .sendMessage(tabId, {
-      type,
-      data,
-    } as CustomMessage<T>)
-    .then(responseCallback);
+
+  const maxAttempts = 10;
+  const retryDelayMs = 200;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await browser.tabs.sendMessage(tabId, {
+        type,
+        data,
+      } as CustomMessage<T>);
+      return responseCallback ? responseCallback(response) : response;
+    } catch (error) {
+      if (!isReceivingEndError(error) || attempt === maxAttempts) {
+        throw error;
+      }
+
+      console.debug("Retrying content script message after connection error", {
+        tabId,
+        type,
+        attempt,
+      });
+      await delay(retryDelayMs);
+    }
+  }
 };

--- a/src/services/backgroundEngine.ts
+++ b/src/services/backgroundEngine.ts
@@ -1,5 +1,6 @@
 import { sendMessageToContentScript } from "@/lib/messages";
 import {
+  CleanupWorkflowTriggersCommand,
   ReadinessResponse,
   TriggerCommand,
   WorkflowCommandType,
@@ -19,10 +20,10 @@ import { initializeBackgroundActions } from "./backgroundActionInitializer";
 
 export class BackgroundWorkflowEngine {
   private activeExecutors = new Map<string, WorkflowExecutor>();
-  private pendingNavigationEvents = new Map<
-    number,
-    { url: string; timeoutId: ReturnType<typeof setTimeout> }
-  >();
+  private activeTabWorkflows = new Map<number, Set<string>>();
+  private activeTabUrls = new Map<number, string>();
+  private tabQueues = new Map<number, Promise<void>>();
+  private tabGenerations = new Map<number, number>();
   private workflows: WorkflowDefinition[] = [];
 
   constructor() {
@@ -37,7 +38,25 @@ export class BackgroundWorkflowEngine {
 
   private setupStoreListener(): void {
     useStore.subscribe((state) => {
+      const currentWorkflowsById = new Map(
+        state.workflows.map((workflow) => [workflow.id, workflow]),
+      );
+      const workflowsToCleanup = this.workflows.filter((workflow) => {
+        const currentWorkflow = currentWorkflowsById.get(workflow.id);
+        return (
+          !currentWorkflow ||
+          !currentWorkflow.enabled ||
+          currentWorkflow.modifiedAt !== workflow.modifiedAt
+        );
+      });
+
       this.workflows = state.workflows;
+
+      for (const workflow of workflowsToCleanup) {
+        this.cleanupWorkflowEverywhere(workflow.id).catch((error) => {
+          console.warn("Failed to cleanup inactive workflow:", error);
+        });
+      }
     });
   }
 
@@ -47,37 +66,61 @@ export class BackgroundWorkflowEngine {
   }
 
   async onNewUrl(tabId: number, url: string): Promise<void> {
-    const pendingNavigation = this.pendingNavigationEvents.get(tabId);
-    // Some sites trigger both onCompleted and onHistoryStateUpdated for the same
-    // navigation, so ignore a repeated tab+URL event in a short window.
-    if (pendingNavigation?.url === url) {
-      return;
-    }
+    const generation = this.getTabGeneration(tabId);
+    const previousQueue = this.tabQueues.get(tabId) || Promise.resolve();
+    const nextQueue = previousQueue
+      .catch(() => {})
+      .then(() => this.handleNewUrl(tabId, url, generation))
+      .finally(() => {
+        if (this.tabQueues.get(tabId) === nextQueue) {
+          this.tabQueues.delete(tabId);
+        }
+      });
 
-    if (pendingNavigation) {
-      clearTimeout(pendingNavigation.timeoutId);
-    }
+    this.tabQueues.set(tabId, nextQueue);
+    await nextQueue;
+  }
 
-    this.pendingNavigationEvents.set(tabId, {
-      url,
-      timeoutId: setTimeout(() => {
-        this.pendingNavigationEvents.delete(tabId);
-      }, 100),
-    });
-
+  private async handleNewUrl(
+    tabId: number,
+    url: string,
+    generation: number,
+  ): Promise<void> {
     // Get the active workflow IDs for this tab
     const runningWorkflowIds = Array.from(this.activeExecutors.values())
       .filter((executor) => executor.tabId === tabId)
       .map((executor) => executor.workflowId);
     // Find workflows that match the URL pattern
-    const matchingWorkflows = this.workflows
-      .filter(
-        (workflow) =>
-          workflow.enabled && matchesUrlPattern(url, workflow.urlPattern, true),
-      )
-      .filter((workflow) => !runningWorkflowIds.includes(workflow.id));
+    const matchingWorkflows = this.workflows.filter(
+      (workflow) =>
+        workflow.enabled && matchesUrlPattern(url, workflow.urlPattern, true),
+    );
+    const matchingWorkflowIds = new Set(
+      matchingWorkflows.map((workflow) => workflow.id),
+    );
+    const activeWorkflowIds =
+      this.activeTabWorkflows.get(tabId) || new Set<string>();
+    const activeUrl = this.activeTabUrls.get(tabId);
 
-    if (matchingWorkflows.length == 0 && runningWorkflowIds.length == 0) {
+    if (
+      activeUrl === url &&
+      BackgroundWorkflowEngine.setsEqual(activeWorkflowIds, matchingWorkflowIds)
+    ) {
+      return;
+    }
+
+    const workflowsToCleanup = Array.from(activeWorkflowIds);
+
+    if (workflowsToCleanup.length > 0) {
+      await this.cleanupTabWorkflows(tabId, workflowsToCleanup);
+    }
+
+    if (this.getTabGeneration(tabId) !== generation) {
+      return;
+    }
+
+    if (matchingWorkflows.length === 0 && runningWorkflowIds.length === 0) {
+      this.activeTabUrls.delete(tabId);
       return;
     }
 
@@ -90,24 +133,88 @@ export class BackgroundWorkflowEngine {
       return;
     }
 
-    // Clean up any previously active triggers before setting up new ones,
-    // so that SPA navigations (back/forward/pushState) don't accumulate
-    // duplicate event listeners.
-    try {
-      await sendMessageToContentScript(
-        tabId,
-        WorkflowCommandType.CLEANUP_TRIGGERS,
-        { type: WorkflowCommandType.CLEANUP_TRIGGERS },
-      );
-    } catch (error) {
-      console.warn("Failed to cleanup triggers:", error);
+    if (this.getTabGeneration(tabId) !== generation) {
+      return;
     }
 
-    matchingWorkflows.forEach((workflow) => {
-      this.getWorkflowTriggers(workflow).forEach((triggerNode) => {
-        this.setupTrigger(tabId, workflow, triggerNode);
-      });
-    });
+    const setupWorkflowIds = new Set<string>();
+    for (const workflow of matchingWorkflows) {
+      for (const triggerNode of this.getWorkflowTriggers(workflow)) {
+        await this.setupTrigger(tabId, workflow, triggerNode);
+        if (this.getTabGeneration(tabId) !== generation) {
+          await this.cleanupTabWorkflows(tabId, [workflow.id]);
+          return;
+        }
+      }
+      setupWorkflowIds.add(workflow.id);
+    }
+
+    this.activeTabWorkflows.set(tabId, setupWorkflowIds);
+    this.activeTabUrls.set(tabId, url);
+  }
+
+  public clearTab(tabId: number): void {
+    this.activeTabWorkflows.delete(tabId);
+    this.activeTabUrls.delete(tabId);
+    this.tabQueues.delete(tabId);
+    this.tabGenerations.set(tabId, this.getTabGeneration(tabId) + 1);
+
+    for (const [executorId, executor] of this.activeExecutors.entries()) {
+      if (executor.tabId === tabId) {
+        this.activeExecutors.delete(executorId);
+      }
+    }
+  }
+
+  private async cleanupTabWorkflows(
+    tabId: number,
+    workflowIds: string[],
+  ): Promise<void> {
+    try {
+      const message: CleanupWorkflowTriggersCommand = {
+        type: WorkflowCommandType.CLEANUP_WORKFLOW_TRIGGERS,
+        workflowIds,
+      };
+
+      await sendMessageToContentScript(
+        tabId,
+        WorkflowCommandType.CLEANUP_WORKFLOW_TRIGGERS,
+        message,
+      );
+    } catch (error) {
+      console.warn("Failed to cleanup workflow triggers:", error);
+    } finally {
+      const activeWorkflowIds = this.activeTabWorkflows.get(tabId);
+      if (activeWorkflowIds) {
+        workflowIds.forEach((workflowId) =>
+          activeWorkflowIds.delete(workflowId),
+        );
+        if (activeWorkflowIds.size === 0) {
+          this.activeTabWorkflows.delete(tabId);
+          this.activeTabUrls.delete(tabId);
+        }
+      }
+    }
+  }
+
+  private async cleanupWorkflowEverywhere(workflowId: string): Promise<void> {
+    const cleanupTasks = Array.from(this.activeTabWorkflows.entries())
+      .filter(([, workflowIds]) => workflowIds.has(workflowId))
+      .map(([tabId]) => this.cleanupTabWorkflows(tabId, [workflowId]));
+
+    await Promise.all(cleanupTasks);
+  }
+
+  private static setsEqual(first: Set<string>, second: Set<string>): boolean {
+    if (first.size !== second.size) return false;
+    for (const value of first) {
+      if (!second.has(value)) return false;
+    }
+    return true;
+  }
+
+  private getTabGeneration(tabId: number): number {
+    return this.tabGenerations.get(tabId) || 0;
   }
 
   private async initializeContentScript(tabId: number): Promise<boolean> {

--- a/src/services/backgroundEngine.ts
+++ b/src/services/backgroundEngine.ts
@@ -281,11 +281,9 @@ export class BackgroundWorkflowEngine {
       // Continue with original config if interpolation fails
     }
 
-    // First, check if content script is ready and initialize it if needed
     try {
       console.debug("Setting up trigger:", triggerType);
 
-      // Now send command to content script to set up the trigger
       const message: TriggerCommand = {
         type: WorkflowCommandType.INIT_TRIGGER,
         workflowId: workflow.id,

--- a/src/services/backgroundEngine.ts
+++ b/src/services/backgroundEngine.ts
@@ -1,7 +1,6 @@
 import { sendMessageToContentScript } from "@/lib/messages";
 import {
   CleanupWorkflowTriggersCommand,
-  ReadinessResponse,
   TriggerCommand,
   WorkflowCommandType,
 } from "@/types/background-workflow";
@@ -13,7 +12,6 @@ import {
 import { WorkflowExecutor } from "./workflow/workflow";
 import { ExecutionContext } from "./workflow/executionContext";
 import { matchesUrlPattern } from "@/utils/helpers";
-import { NotificationService } from "./notification";
 import { initializeCredentials } from "./credentialInitializer";
 import { useStore } from "@/store";
 import { initializeBackgroundActions } from "./backgroundActionInitializer";
@@ -102,16 +100,33 @@ export class BackgroundWorkflowEngine {
       this.activeTabWorkflows.get(tabId) || new Set<string>();
     const activeUrl = this.activeTabUrls.get(tabId);
 
+    console.debug("BackgroundWorkflowEngine: Evaluating URL", {
+      tabId,
+      url,
+      previousUrl: activeUrl,
+      activeWorkflowIds: Array.from(activeWorkflowIds),
+      matchingWorkflowIds: Array.from(matchingWorkflowIds),
+      generation,
+    });
+
     if (
       activeUrl === url &&
       BackgroundWorkflowEngine.setsEqual(activeWorkflowIds, matchingWorkflowIds)
     ) {
+      console.debug("BackgroundWorkflowEngine: URL evaluation unchanged", {
+        tabId,
+        url,
+      });
       return;
     }
 
     const workflowsToCleanup = Array.from(activeWorkflowIds);
 
     if (workflowsToCleanup.length > 0) {
+      console.debug("BackgroundWorkflowEngine: Cleaning up workflows", {
+        tabId,
+        workflowIds: workflowsToCleanup,
+      });
       await this.cleanupTabWorkflows(tabId, workflowsToCleanup);
     }
 
@@ -120,20 +135,11 @@ export class BackgroundWorkflowEngine {
     }
 
     if (matchingWorkflows.length === 0 && runningWorkflowIds.length === 0) {
-      this.activeTabUrls.delete(tabId);
-      return;
-    }
-
-    const success = await this.initializeContentScript(tabId);
-    if (!success) {
-      NotificationService.showErrorNotificationFromBackground({
-        title: "Failed to start workflow",
-        message: `Could not initialize content script for workflows on this page.`,
+      console.debug("BackgroundWorkflowEngine: No matching workflows", {
+        tabId,
+        url,
       });
-      return;
-    }
-
-    if (this.getTabGeneration(tabId) !== generation) {
+      this.activeTabUrls.delete(tabId);
       return;
     }
 
@@ -151,6 +157,11 @@ export class BackgroundWorkflowEngine {
 
     this.activeTabWorkflows.set(tabId, setupWorkflowIds);
     this.activeTabUrls.set(tabId, url);
+    console.debug("BackgroundWorkflowEngine: Activated workflows", {
+      tabId,
+      url,
+      workflowIds: Array.from(setupWorkflowIds),
+    });
   }
 
   public clearTab(tabId: number): void {
@@ -215,45 +226,6 @@ export class BackgroundWorkflowEngine {
 
   private getTabGeneration(tabId: number): number {
     return this.tabGenerations.get(tabId) || 0;
-  }
-
-  private async initializeContentScript(tabId: number): Promise<boolean> {
-    return BackgroundWorkflowEngine.waitForContentScriptReady(tabId);
-  }
-
-  static async waitForContentScriptReady(
-    tabId: number,
-    timeoutMs: number = 10000,
-    retryIntervalMs: number = 500,
-  ): Promise<boolean> {
-    const startTime = Date.now();
-
-    while (Date.now() - startTime < timeoutMs) {
-      try {
-        const readinessResponse = (await sendMessageToContentScript(
-          tabId,
-          WorkflowCommandType.CHECK_READINESS,
-        )) as ReadinessResponse;
-
-        if (readinessResponse?.ready) {
-          console.debug("Content script ready for tab:", tabId);
-          return true;
-        }
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        console.debug(
-          "Content script not yet ready for tab:",
-          tabId,
-          errorMessage,
-        );
-      }
-
-      // Wait before retrying
-      await new Promise((resolve) => setTimeout(resolve, retryIntervalMs));
-    }
-
-    return false;
   }
 
   private async setupTrigger(

--- a/src/services/chatbot/chat-storage.ts
+++ b/src/services/chatbot/chat-storage.ts
@@ -59,6 +59,24 @@ export const appendUserMessage = (workflowId: string, content: string) => {
   });
 };
 
+export const appendAssistantMessage = (workflowId: string, content: string) => {
+  const session = getSession(workflowId);
+  if (!session) {
+    throw new Error(`Session not found for workflowId: ${workflowId}`);
+  }
+
+  const assistantMessage: UIMessage = {
+    id: generateId("message", 16),
+    role: "assistant",
+    parts: [{ type: "text", text: content }],
+  };
+
+  saveSession({
+    workflowId,
+    messages: [...session.messages, assistantMessage],
+  });
+};
+
 export const getProvider = () =>
   useStore.getState().settings.workfowGeneration.provider;
 export const getModel = () =>

--- a/src/services/chatbot/index.ts
+++ b/src/services/chatbot/index.ts
@@ -2,6 +2,7 @@ import { CustomMessage, sendMessageToBackground } from "@/lib/messages";
 import browser from "../browser";
 import { MessageType } from "@/types/messages";
 import {
+  appendAssistantMessage,
   getCredential,
   getModel,
   getProvider,
@@ -25,7 +26,25 @@ import { API_BASE_URL } from "@/api/client";
 import { generateId } from "@/utils/helpers";
 import buildSystemPrompt from "./system-prompt";
 import { createTools } from "./tools";
+import { validateWorkflow, WorkflowValidationReport } from "./workflowTools";
 import { WorkflowDefinition } from "@/types/workflow";
+
+function formatValidationMessage(report: WorkflowValidationReport) {
+  const lines = ["Workflow validation complete.", report.summary];
+
+  if (report.errors.length > 0) {
+    lines.push("Errors:", ...report.errors.map((error) => `- ${error}`));
+  }
+
+  if (report.warnings.length > 0) {
+    lines.push(
+      "Warnings:",
+      ...report.warnings.map((warning) => `- ${warning}`),
+    );
+  }
+
+  return lines.join("\n");
+}
 
 export class ChatbotService {
   private static instance: ChatbotService;
@@ -108,10 +127,12 @@ export class ChatbotService {
         session.messages.slice(-20),
       );
       let workflowState: WorkflowDefinition = getWorkflow(workflowId);
+      let workflowChanged = false;
 
       const getWorkflowState = () => workflowState;
       const saveWorkflowState = (workflow: WorkflowDefinition) => {
         workflowState = workflow;
+        workflowChanged = true;
         saveWorkflow(workflow);
       };
 
@@ -129,7 +150,7 @@ export class ChatbotService {
         temperature: 0.2,
         maxOutputTokens: 2000,
         abortSignal: this.activeRuns[workflowId].signal,
-        stopWhen: stepCountIs(10),
+        stopWhen: stepCountIs(20),
         onError({ error }) {
           streamError =
             error instanceof Error ? error : new Error(String(error));
@@ -150,6 +171,15 @@ export class ChatbotService {
       if (streamError) {
         setStatus(workflowId, "error", streamError.message);
       } else {
+        if (workflowChanged) {
+          const validation = validateWorkflow(workflowState);
+          if (validation.errors.length > 0 || validation.warnings.length > 0) {
+            appendAssistantMessage(
+              workflowId,
+              formatValidationMessage(validation),
+            );
+          }
+        }
         setStatus(workflowId, "ready");
       }
     } catch (error) {

--- a/src/services/chatbot/system-prompt.ts
+++ b/src/services/chatbot/system-prompt.ts
@@ -1,4 +1,4 @@
-import { WorkflowDefinition } from "@/types/workflow";
+import { ExecutionMetadataKeys, WorkflowDefinition } from "@/types/workflow";
 import { nodeCatalog } from "../nodeCatalog";
 
 interface SystemPromptProps {
@@ -17,6 +17,10 @@ const availableNodeTypes = {
     description: node.metadata.description,
   })),
 };
+
+const availableMetadataVariables = ExecutionMetadataKeys.map(
+  (key) => `{{meta.${key}}}`,
+);
 
 export default function buildSystemPrompt({ workflow }: SystemPromptProps) {
   return [
@@ -37,12 +41,16 @@ export default function buildSystemPrompt({ workflow }: SystemPromptProps) {
     "Building workflows: Use tools in this order when needed: create node, update node config, then connect nodes.",
     "After creating or rewiring nodes, call autoArrangeNodes once the intended structure is in place so the workflow ends in a clean layout.",
     "Use setWorkflowName, setWorkflowDescription, setUrlPattern, and setWorkflowEnabled for workflow-level changes.",
-    "After any workflow change, finish by calling validateWorkflow. If it reports issues, fix them and call validateWorkflow again so validation is the final workflow step you take.",
-    "When the workflow is ready, set a clear workflow name, make validateWorkflow your final workflow step, and only then enable it.",
+    "After structural or config workflow changes, read the validation feedback returned by the tool. If it reports issues, fix them and call validateWorkflow again so validation is the final workflow step you take.",
+    "When the workflow is ready, set a clear workflow name and make validateWorkflow your final workflow step before replying that the work is done.",
+    "Validation findings do not prevent enabling or running a workflow. The user may still run an invalid workflow to inspect execution errors with getLatestExecution.",
     "Do NOT call setWorkflowEnabled after every edit. Preserve the current enabled state during intermediate changes.",
     "Only call setWorkflowEnabled when you are finishing a newly created workflow, when the user explicitly asks to enable or disable it, or when the workflow must be re-enabled after it was intentionally disabled.",
     "When creating nodes, use the exact node-type tool names and fields.",
-    "Workflow variables use Liquid syntax. Use '{{ variableName }}' placeholders in string fields for runtime substitution.",
+    "Workflow variables use Liquid syntax in string fields.",
+    `Available execution metadata variables: ${availableMetadataVariables.join(", ")}.`,
+    "Workflow-defined variables use {{env.variableName}}.",
+    "Previous node output can be referenced as {{prev.property}} when configuring an action connected after another node.",
     "Node IDs are generated automatically by the app as action-* or trigger-*; do not invent node IDs.",
     "CRITICAL: Before using Liquid variables like {{node-id.property}}, you MUST call getNodeSchema on the source node type to inspect the exact output structure. Never guess property names.",
     "Common mistake: assuming a node outputs {text: ...} when it actually outputs {content: ...}. Always verify with getNodeSchema first.",

--- a/src/services/chatbot/tools.ts
+++ b/src/services/chatbot/tools.ts
@@ -44,6 +44,14 @@ export function createTools({
     ...details,
   });
 
+  const buildWorkflowMutationResult = (message: string) => {
+    const validation = validateWorkflow(getWorkflowState());
+
+    return buildToolResult(message, {
+      validation,
+    });
+  };
+
   const applyWorkflowChange = (
     mutate: (workflow: WorkflowDefinition) => WorkflowDefinition,
   ) => {
@@ -64,7 +72,7 @@ export function createTools({
     return async (args: TArgs) => {
       const { workflow, result } = mutate(getWorkflowState(), args);
       saveWorkflowState(workflow);
-      return { message: result };
+      return buildWorkflowMutationResult(result);
     };
   };
 

--- a/src/services/chatbot/workflowTools.ts
+++ b/src/services/chatbot/workflowTools.ts
@@ -1,4 +1,5 @@
 import {
+  ExecutionMetadataKeys,
   WorkflowConnection,
   WorkflowDefinition,
   WorkflowNode,
@@ -145,6 +146,36 @@ function validateNodeReference(
   ref: string,
 ): { error?: string; warning?: string } {
   const [nodeId, ...propertyPath] = ref.split(".");
+
+  if (nodeId === "page") {
+    return {
+      error:
+        ref === "page.url"
+          ? "uses invalid variable '{{page.url}}'. Use '{{meta.url}}' for the current page URL."
+          : `uses invalid variable namespace 'page'. Use 'meta' for execution metadata. Available metadata fields: ${ExecutionMetadataKeys.join(", ")}`,
+    };
+  }
+
+  if (nodeId === "meta") {
+    const [metadataKey] = propertyPath;
+    if (!metadataKey) {
+      return {
+        warning: `references metadata namespace 'meta' without a field. Available metadata fields: ${ExecutionMetadataKeys.join(", ")}`,
+      };
+    }
+
+    if (!ExecutionMetadataKeys.includes(metadataKey as any)) {
+      return {
+        error: `references invalid metadata field 'meta.${metadataKey}'. Available metadata fields: ${ExecutionMetadataKeys.join(", ")}`,
+      };
+    }
+
+    return {};
+  }
+
+  if (nodeId === "env" || nodeId === "prev") {
+    return {};
+  }
 
   if (!isLikelyNodeReference(nodeId, workflow)) {
     return {};
@@ -459,6 +490,11 @@ export function createNode(
   }
 
   const nodeType = inferNodeType(type, args);
+  const definition = getNodeDefinition(nodeType, type);
+  if (!definition) {
+    throw new Error(`Unknown ${nodeType} node type '${type}'`);
+  }
+
   const nodeId =
     getFirstString(args, ["id", "nodeId", "node_id"]) ||
     generateId(nodeType, 8);
@@ -489,13 +525,30 @@ export function createNode(
     outputs,
   };
 
+  validateConfigPatchKeys(node, config);
+
+  const variableValidation = validateConfigVariables(workflow, config, {
+    allowMissingReferencedNodes: true,
+  });
+  if (variableValidation.errors.length > 0) {
+    throw new Error(variableValidation.errors.join("; "));
+  }
+
   return {
     workflow: {
       ...workflow,
       nodes: [...workflow.nodes, node],
       modifiedAt: Date.now(),
     },
-    result: `Created ${nodeType} node '${type}' (${nodeId}).`,
+    result: [
+      `Created ${nodeType} node '${type}' (${nodeId}).`,
+      variableValidation.hasLiquidReferences
+        ? "Config uses Liquid variables. After wiring the workflow, call validateWorkflow to verify node references and output properties, and keep validation as your final workflow step before enabling it or declaring the workflow finished."
+        : null,
+      ...variableValidation.warnings,
+    ]
+      .filter(Boolean)
+      .join(" "),
   };
 }
 

--- a/src/services/httpListenerWebRequest.ts
+++ b/src/services/httpListenerWebRequest.ts
@@ -85,6 +85,25 @@ export class HttpListenerWebRequest {
     }
   }
 
+  unregisterTrigger(
+    tabId: number,
+    workflowId: string,
+    triggerNodeId: string,
+  ): void {
+    this.triggers = this.triggers.filter(
+      (trigger) =>
+        !(
+          trigger.tabId === tabId &&
+          trigger.workflowId === workflowId &&
+          trigger.triggerNodeId === triggerNodeId
+        ),
+    );
+
+    if (this.triggers.length === 0) {
+      this.stopListening();
+    }
+  }
+
   private startListening(): void {
     if (this.isListening) return;
 

--- a/src/services/injector.ts
+++ b/src/services/injector.ts
@@ -4,12 +4,20 @@ import CustomMantineProvider from "@/content/mantineProvider";
 
 const MANTINE_INJECTOR_ROOT_ID = "mantine-injector-root";
 export class ContentInjector {
+  private static roots = new Map<string, Root>();
   private urlObserver: MutationObserver | null = null;
   private processTimeout: number | null = null;
 
   async initialize(): Promise<void> {
     console.debug("Content injector initialized");
     this.injectMantineDispatcher(MANTINE_INJECTOR_ROOT_ID);
+  }
+
+  ensureInitialized(): void {
+    const existing = document.getElementById(MANTINE_INJECTOR_ROOT_ID);
+    if (!existing || !ContentInjector.roots.has(MANTINE_INJECTOR_ROOT_ID)) {
+      this.reinjectMantineDispatcher(MANTINE_INJECTOR_ROOT_ID);
+    }
   }
 
   private static getParentShadowRoot(
@@ -87,6 +95,17 @@ export class ContentInjector {
         coreOnly,
       }),
     );
+    this.roots.set(rootId, root);
+  }
+
+  private static removeInjectedRoot(rootId: string): void {
+    const root = this.roots.get(rootId);
+    if (root) {
+      root.unmount();
+      this.roots.delete(rootId);
+    }
+
+    document.getElementById(rootId)?.remove();
   }
 
   private injectMantineDispatcher(rootId: string): void {
@@ -104,6 +123,11 @@ export class ContentInjector {
     );
   }
 
+  private reinjectMantineDispatcher(rootId: string): void {
+    ContentInjector.removeInjectedRoot(rootId);
+    this.injectMantineDispatcher(rootId);
+  }
+
   private cleanupInjectedComponents(): void {
     console.debug("Cleaning up injected components");
 
@@ -116,8 +140,8 @@ export class ContentInjector {
       '[data-workflow-injected="true"]:not(#mantine-injector-root)',
     );
     injectedComponents.forEach((component) => {
-      if (component.parentNode) {
-        component.parentNode.removeChild(component);
+      if (component instanceof HTMLElement) {
+        ContentInjector.removeInjectedRoot(component.id);
       }
     });
   }

--- a/src/services/injector.ts
+++ b/src/services/injector.ts
@@ -7,17 +7,14 @@ export class ContentInjector {
   private static roots = new Map<string, Root>();
   private urlObserver: MutationObserver | null = null;
   private processTimeout: number | null = null;
+  private isDestroyed = false;
+  private isEnsuringMantineRoot = false;
 
   async initialize(): Promise<void> {
     console.debug("Content injector initialized");
-    this.injectMantineDispatcher(MANTINE_INJECTOR_ROOT_ID);
-  }
-
-  ensureInitialized(): void {
-    const existing = document.getElementById(MANTINE_INJECTOR_ROOT_ID);
-    if (!existing || !ContentInjector.roots.has(MANTINE_INJECTOR_ROOT_ID)) {
-      this.reinjectMantineDispatcher(MANTINE_INJECTOR_ROOT_ID);
-    }
+    this.isDestroyed = false;
+    this.ensureMantineRoot();
+    this.observeMantineRoot();
   }
 
   private static getParentShadowRoot(
@@ -98,6 +95,10 @@ export class ContentInjector {
     this.roots.set(rootId, root);
   }
 
+  public static removeInjectedComponent(rootId: string): void {
+    this.removeInjectedRoot(rootId);
+  }
+
   private static removeInjectedRoot(rootId: string): void {
     const root = this.roots.get(rootId);
     if (root) {
@@ -123,9 +124,63 @@ export class ContentInjector {
     );
   }
 
-  private reinjectMantineDispatcher(rootId: string): void {
-    ContentInjector.removeInjectedRoot(rootId);
-    this.injectMantineDispatcher(rootId);
+  private ensureMantineRoot(): void {
+    if (this.isDestroyed || this.isEnsuringMantineRoot) {
+      return;
+    }
+
+    const existingRoot = document.getElementById(MANTINE_INJECTOR_ROOT_ID);
+    const hasMountedRoot = ContentInjector.roots.has(MANTINE_INJECTOR_ROOT_ID);
+    if (existingRoot && hasMountedRoot) {
+      return;
+    }
+
+    this.isEnsuringMantineRoot = true;
+    try {
+      if (existingRoot && !hasMountedRoot) {
+        existingRoot.remove();
+      }
+
+      if (!existingRoot && hasMountedRoot) {
+        ContentInjector.removeInjectedComponent(MANTINE_INJECTOR_ROOT_ID);
+      }
+
+      console.debug("Content injector: restoring mantine root");
+      this.injectMantineDispatcher(MANTINE_INJECTOR_ROOT_ID);
+    } finally {
+      this.isEnsuringMantineRoot = false;
+    }
+  }
+
+  private observeMantineRoot(): void {
+    if (this.urlObserver) {
+      this.urlObserver.disconnect();
+    }
+
+    const observerTarget = document.documentElement;
+    if (!observerTarget) {
+      return;
+    }
+
+    this.urlObserver = new MutationObserver(() => {
+      if (this.isDestroyed || this.isEnsuringMantineRoot) {
+        return;
+      }
+
+      if (this.processTimeout !== null) {
+        window.clearTimeout(this.processTimeout);
+      }
+
+      this.processTimeout = window.setTimeout(() => {
+        this.processTimeout = null;
+        this.ensureMantineRoot();
+      }, 50);
+    });
+
+    this.urlObserver.observe(observerTarget, {
+      childList: true,
+      subtree: true,
+    });
   }
 
   private cleanupInjectedComponents(): void {
@@ -147,13 +202,17 @@ export class ContentInjector {
   }
 
   destroy(): void {
-    this.cleanupInjectedComponents();
+    this.isDestroyed = true;
 
     if (this.urlObserver) {
       this.urlObserver.disconnect();
+      this.urlObserver = null;
     }
     if (this.processTimeout) {
       clearTimeout(this.processTimeout);
+      this.processTimeout = null;
     }
+
+    this.cleanupInjectedComponents();
   }
 }

--- a/src/services/triggerRegistry.ts
+++ b/src/services/triggerRegistry.ts
@@ -1,9 +1,10 @@
 import { ValidationResult } from "@/types/config-properties";
-import { BaseTrigger, TriggerMetadata } from "@/types/triggers";
+import { BaseTrigger, TriggerCleanup, TriggerMetadata } from "@/types/triggers";
 
 export class TriggerRegistry {
   private static instance: TriggerRegistry;
   private triggers = new Map<string, BaseTrigger>();
+  private activeTriggerCleanups = new Map<string, TriggerCleanup>();
 
   private constructor() {}
 
@@ -75,15 +76,22 @@ export class TriggerRegistry {
 
     // Setup with defaults applied
     const configWithDefaults = trigger.getConfigWithDefaults(config);
+    const activeKey = this.getActiveTriggerKey(workflowId, nodeId);
+    await this.cleanupByKey(activeKey);
+
     const onTriggerWrapper = async (data?: any) => {
       await onTrigger(configWithDefaults, data);
     };
-    await trigger.setup(
+    const cleanup = await trigger.setup(
       configWithDefaults,
       workflowId,
       nodeId,
       onTriggerWrapper,
     );
+
+    if (cleanup) {
+      this.activeTriggerCleanups.set(activeKey, cleanup);
+    }
   }
 
   // Validate trigger configuration
@@ -118,9 +126,36 @@ export class TriggerRegistry {
 
   // Clean up all active triggers (remove event listeners, observers, timeouts, injected elements)
   async cleanupAll(): Promise<void> {
+    for (const key of Array.from(this.activeTriggerCleanups.keys())) {
+      await this.cleanupByKey(key);
+    }
+
     for (const trigger of this.triggers.values()) {
       await trigger.cleanup();
     }
+  }
+
+  async cleanupByWorkflow(workflowId: string): Promise<void> {
+    const prefix = `${workflowId}:`;
+    const keys = Array.from(this.activeTriggerCleanups.keys()).filter((key) =>
+      key.startsWith(prefix),
+    );
+
+    for (const key of keys) {
+      await this.cleanupByKey(key);
+    }
+  }
+
+  private async cleanupByKey(key: string): Promise<void> {
+    const cleanup = this.activeTriggerCleanups.get(key);
+    if (!cleanup) return;
+
+    this.activeTriggerCleanups.delete(key);
+    await cleanup();
+  }
+
+  private getActiveTriggerKey(workflowId: string, nodeId: string): string {
+    return `${workflowId}:${nodeId}`;
   }
 
   // Get trigger categories for UI (compatible with existing NODE_CATEGORIES)

--- a/src/services/triggers/button-click.runtime.ts
+++ b/src/services/triggers/button-click.runtime.ts
@@ -48,16 +48,6 @@ export class ButtonClickTrigger extends BaseTrigger<
       customStyle,
       injectionPosition,
     } = config;
-    const targetElement =
-      componentType === "fab"
-        ? document.body
-        : await waitForElement(targetSelector, selectorType, 5000);
-    if (!targetElement) {
-      NotificationService.showErrorNotification({
-        message: "Target element not found for component injection",
-      });
-      return;
-    }
     const componentConfig = {
       componentType,
       componentText,
@@ -66,13 +56,50 @@ export class ButtonClickTrigger extends BaseTrigger<
       customStyle,
     };
     const containerId = `container-${workflowId}-${nodeId}`;
-    ContentInjector.injectMantineComponentInTarget(
-      containerId,
-      ComponentFactory.create(componentConfig, workflowId, nodeId),
-      targetElement,
-      true,
-      injectionPosition,
-    );
+    let isActive = true;
+    let isInjecting = false;
+    let currentTarget: Element | null = null;
+
+    const injectComponent = async () => {
+      if (!isActive || isInjecting) {
+        return;
+      }
+
+      isInjecting = true;
+
+      try {
+        const targetElement =
+          componentType === "fab"
+            ? document.body
+            : await waitForElement(targetSelector, selectorType, 5000);
+
+        if (!isActive) {
+          return;
+        }
+
+        if (!targetElement) {
+          NotificationService.showErrorNotification({
+            message: "Target element not found for component injection",
+          });
+          return;
+        }
+
+        currentTarget = targetElement;
+        ContentInjector.removeInjectedComponent(containerId);
+        ContentInjector.injectMantineComponentInTarget(
+          containerId,
+          ComponentFactory.create(componentConfig, workflowId, nodeId),
+          targetElement,
+          true,
+          injectionPosition,
+        );
+      } finally {
+        isInjecting = false;
+      }
+    };
+
+    await injectComponent();
+
     const handleComponentTrigger = (
       event: CustomEventInit<ComponentTriggerEventDetail>,
     ) => {
@@ -93,13 +120,33 @@ export class ButtonClickTrigger extends BaseTrigger<
       handleComponentTrigger,
     );
 
+    const observer = new MutationObserver(() => {
+      if (!isActive || isInjecting) {
+        return;
+      }
+
+      const container = document.getElementById(containerId);
+      const targetDetached =
+        currentTarget !== null && !document.contains(currentTarget);
+
+      if (!container || !document.contains(container) || targetDetached) {
+        void injectComponent();
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
     return () => {
+      isActive = false;
+      observer.disconnect();
       document.removeEventListener(
         "workflow-component-trigger",
         handleComponentTrigger,
       );
-      const container = document.getElementById(containerId);
-      container?.remove();
+      ContentInjector.removeInjectedComponent(containerId);
     };
   }
 }

--- a/src/services/triggers/button-click.runtime.ts
+++ b/src/services/triggers/button-click.runtime.ts
@@ -28,8 +28,6 @@ export class ButtonClickTrigger extends BaseTrigger<
   ButtonClickTriggerConfig,
   ButtonClickTriggerOutput
 > {
-  private cleanupFns: (() => void)[] = [];
-
   constructor() {
     super(definition);
   }
@@ -39,7 +37,7 @@ export class ButtonClickTrigger extends BaseTrigger<
     workflowId: string,
     nodeId: string,
     onTrigger: (data?: any) => Promise<void>,
-  ): Promise<void> {
+  ): Promise<(() => void) | void> {
     const {
       selectorType,
       targetSelector,
@@ -67,14 +65,10 @@ export class ButtonClickTrigger extends BaseTrigger<
       buttonTextColor,
       customStyle,
     };
-    const component = ComponentFactory.create(
-      componentConfig,
-      workflowId,
-      nodeId,
-    );
+    const containerId = `container-${workflowId}-${nodeId}`;
     ContentInjector.injectMantineComponentInTarget(
-      `container-${workflowId}-${nodeId}`,
-      component,
+      containerId,
+      ComponentFactory.create(componentConfig, workflowId, nodeId),
       targetElement,
       true,
       injectionPosition,
@@ -99,18 +93,13 @@ export class ButtonClickTrigger extends BaseTrigger<
       handleComponentTrigger,
     );
 
-    this.cleanupFns.push(() => {
+    return () => {
       document.removeEventListener(
         "workflow-component-trigger",
         handleComponentTrigger,
       );
-      const container = document.getElementById(`container-${workflowId}-${nodeId}`);
+      const container = document.getElementById(containerId);
       container?.remove();
-    });
-  }
-
-  async cleanup(): Promise<void> {
-    this.cleanupFns.forEach((fn) => fn());
-    this.cleanupFns = [];
+    };
   }
 }

--- a/src/services/triggers/button-click.runtime.ts
+++ b/src/services/triggers/button-click.runtime.ts
@@ -134,7 +134,7 @@ export class ButtonClickTrigger extends BaseTrigger<
       }
     });
 
-    observer.observe(document.body, {
+    observer.observe(document.documentElement, {
       childList: true,
       subtree: true,
     });

--- a/src/services/triggers/component-load.runtime.ts
+++ b/src/services/triggers/component-load.runtime.ts
@@ -16,8 +16,6 @@ export class ComponentLoadTrigger extends BaseTrigger<
   ComponentLoadTriggerConfig,
   ComponentLoadTriggerOutput
 > {
-  private cleanupFns: (() => void)[] = [];
-
   constructor() {
     super(definition);
   }
@@ -27,7 +25,7 @@ export class ComponentLoadTrigger extends BaseTrigger<
     _workflowId: string,
     _nodeId: string,
     onTrigger: (data: ComponentLoadTriggerOutput) => Promise<void>,
-  ): Promise<void> {
+  ): Promise<(() => void) | void> {
     const selector = config.selector;
     let hasTriggered = false;
 
@@ -61,11 +59,6 @@ export class ComponentLoadTrigger extends BaseTrigger<
       subtree: true,
     });
 
-    this.cleanupFns.push(() => observer.disconnect());
-  }
-
-  async cleanup(): Promise<void> {
-    this.cleanupFns.forEach((fn) => fn());
-    this.cleanupFns = [];
+    return () => observer.disconnect();
   }
 }

--- a/src/services/triggers/delay.runtime.ts
+++ b/src/services/triggers/delay.runtime.ts
@@ -10,8 +10,6 @@ interface DelayTriggerOutput {
 }
 
 export class DelayTrigger extends BaseTrigger<DelayTriggerConfig, DelayTriggerOutput> {
-  private cleanupFns: (() => void)[] = [];
-
   constructor() {
     super(definition);
   }
@@ -21,18 +19,13 @@ export class DelayTrigger extends BaseTrigger<DelayTriggerConfig, DelayTriggerOu
     _workflowId: string,
     _nodeId: string,
     onTrigger: (data: DelayTriggerOutput) => Promise<void>,
-  ): Promise<void> {
+  ): Promise<() => void> {
     const delay = config.delay;
 
     const timeoutId = window.setTimeout(async () => {
       await onTrigger({ delay, timestamp: Date.now() });
     }, delay * 1000);
 
-    this.cleanupFns.push(() => clearTimeout(timeoutId));
-  }
-
-  async cleanup(): Promise<void> {
-    this.cleanupFns.forEach((fn) => fn());
-    this.cleanupFns = [];
+    return () => clearTimeout(timeoutId);
   }
 }

--- a/src/services/triggers/http-trigger.runtime.ts
+++ b/src/services/triggers/http-trigger.runtime.ts
@@ -19,8 +19,6 @@ export default class HttpTrigger extends BaseTrigger<
   HttpRequestTriggerConfig,
   HttpRequestTriggerOutput
 > {
-  private cleanupFns: (() => void)[] = [];
-
   constructor() {
     super(definition);
   }
@@ -30,7 +28,7 @@ export default class HttpTrigger extends BaseTrigger<
     workflowId: string,
     nodeId: string,
     onTrigger: (data: HttpRequestTriggerOutput) => Promise<void>,
-  ): Promise<void> {
+  ): Promise<() => void> {
     const { urlPattern, method } = config;
     if (!urlPattern)
       throw new Error("URL pattern is required for HTTP request trigger");
@@ -57,17 +55,18 @@ export default class HttpTrigger extends BaseTrigger<
       return;
     };
     browser.runtime.onMessage.addListener(messageListener);
-    this.cleanupFns.push(() => browser.runtime.onMessage.removeListener(messageListener));
     console.debug("HTTP Request Trigger registered with background script", {
       workflowId,
       triggerNodeId: nodeId,
       urlPattern,
       method,
     });
-  }
-
-  async cleanup(): Promise<void> {
-    this.cleanupFns.forEach((fn) => fn());
-    this.cleanupFns = [];
+    return () => {
+      browser.runtime.onMessage.removeListener(messageListener);
+      sendMessageToBackground("UNREGISTER_HTTP_TRIGGER", {
+        workflowId,
+        triggerNodeId: nodeId,
+      });
+    };
   }
 }

--- a/src/services/triggers/key-press.runtime.tsx
+++ b/src/services/triggers/key-press.runtime.tsx
@@ -13,8 +13,6 @@ export class KeyPressTrigger extends BaseTrigger<
   KeyPressTriggerConfig,
   KeyPressTriggerOutput
 > {
-  private cleanupFns: (() => void)[] = [];
-
   constructor() {
     super(definition);
   }
@@ -24,7 +22,7 @@ export class KeyPressTrigger extends BaseTrigger<
     _workflowId: string,
     _nodeId: string,
     onTrigger: (data: KeyPressTriggerOutput) => Promise<void>,
-  ): Promise<void> {
+  ): Promise<(() => void) | void> {
     const { keyCombo } = config;
     if (!keyCombo) {
       console.warn("No key combination configured for key press trigger");
@@ -38,12 +36,7 @@ export class KeyPressTrigger extends BaseTrigger<
       }
     };
     window.addEventListener("keyup", handleKeyPress);
-    this.cleanupFns.push(() => window.removeEventListener("keyup", handleKeyPress));
-  }
-
-  async cleanup(): Promise<void> {
-    this.cleanupFns.forEach((fn) => fn());
-    this.cleanupFns = [];
+    return () => window.removeEventListener("keyup", handleKeyPress);
   }
 
   private formatKeyCombo(event: KeyboardEvent): string {

--- a/src/services/triggers/page-load.runtime.ts
+++ b/src/services/triggers/page-load.runtime.ts
@@ -9,17 +9,31 @@ interface PageLoadTriggerOutput {
 }
 
 export class PageLoadTrigger extends BaseTrigger<PageLoadTriggerConfig, PageLoadTriggerOutput> {
+  private firedUrls = new Map<string, string>();
+
   constructor() {
     super(definition);
   }
 
   async setup(
     _config: PageLoadTriggerConfig,
-    _workflowId: string,
-    _nodeId: string,
+    workflowId: string,
+    nodeId: string,
     onTrigger: (data: PageLoadTriggerOutput) => Promise<void>,
-  ): Promise<void> {
+  ): Promise<(() => void) | void> {
     // Page is already loaded when this is called, so trigger immediately
-    await onTrigger({ url: window.location.href });
+    const activeKey = `${workflowId}:${nodeId}`;
+    const url = window.location.href;
+
+    if (this.firedUrls.get(activeKey) !== url) {
+      this.firedUrls.set(activeKey, url);
+      await onTrigger({ url });
+    }
+
+    return () => {
+      if (window.location.href !== url) {
+        this.firedUrls.delete(activeKey);
+      }
+    };
   }
 }

--- a/src/services/triggers/page-load.runtime.ts
+++ b/src/services/triggers/page-load.runtime.ts
@@ -9,31 +9,16 @@ interface PageLoadTriggerOutput {
 }
 
 export class PageLoadTrigger extends BaseTrigger<PageLoadTriggerConfig, PageLoadTriggerOutput> {
-  private firedUrls = new Map<string, string>();
-
   constructor() {
     super(definition);
   }
 
   async setup(
     _config: PageLoadTriggerConfig,
-    workflowId: string,
-    nodeId: string,
+    _workflowId: string,
+    _nodeId: string,
     onTrigger: (data: PageLoadTriggerOutput) => Promise<void>,
   ): Promise<(() => void) | void> {
-    // Page is already loaded when this is called, so trigger immediately
-    const activeKey = `${workflowId}:${nodeId}`;
-    const url = window.location.href;
-
-    if (this.firedUrls.get(activeKey) !== url) {
-      this.firedUrls.set(activeKey, url);
-      await onTrigger({ url });
-    }
-
-    return () => {
-      if (window.location.href !== url) {
-        this.firedUrls.delete(activeKey);
-      }
-    };
+    await onTrigger({ url: window.location.href });
   }
 }

--- a/src/services/triggers/popup.runtime.ts
+++ b/src/services/triggers/popup.runtime.ts
@@ -13,8 +13,6 @@ export class PopupTrigger extends BaseTrigger<
   PopupTriggerConfig,
   PopupTriggerOutput
 > {
-  private cleanupFns: (() => void)[] = [];
-
   constructor() {
     super(definition);
   }
@@ -24,7 +22,7 @@ export class PopupTrigger extends BaseTrigger<
     workflowId: string,
     _nodeId: string,
     onTrigger: (data: PopupTriggerOutput) => Promise<void>,
-  ): Promise<void> {
+  ): Promise<() => void> {
     const messageListener = (
       message: CustomMessage,
       _sender: any,
@@ -39,11 +37,6 @@ export class PopupTrigger extends BaseTrigger<
       }
     };
     browser.runtime.onMessage.addListener(messageListener);
-    this.cleanupFns.push(() => browser.runtime.onMessage.removeListener(messageListener));
-  }
-
-  async cleanup(): Promise<void> {
-    this.cleanupFns.forEach((fn) => fn());
-    this.cleanupFns = [];
+    return () => browser.runtime.onMessage.removeListener(messageListener);
   }
 }

--- a/src/services/workflow/workflow.ts
+++ b/src/services/workflow/workflow.ts
@@ -16,7 +16,6 @@ import {
 import { ActionRegistry } from "../actionRegistry";
 import { NotificationService } from "../notification";
 import { ExecutionContext } from "./executionContext";
-import { BackgroundWorkflowEngine } from "../backgroundEngine";
 import { useSessionStore } from "@/store";
 
 export class WorkflowExecutor {
@@ -204,24 +203,6 @@ export class WorkflowExecutor {
         nodeId: node.id,
       };
       const start = Date.now();
-
-      // For content script actions, ensure content script is ready before executing
-      const isReady = await BackgroundWorkflowEngine.waitForContentScriptReady(
-        this.tabId,
-      );
-      if (!isReady) {
-        this.executionTracker.addNodeResult({
-          nodeId: node.id,
-          nodeType: "action",
-          nodeName: actionType,
-          nodeConfig: actionConfig,
-          data: "Timeout waiting for content script to be ready",
-          status: "error",
-          executedAt: start,
-          duration: Date.now() - start,
-        });
-        throw new Error("Timed out waiting for content script to be ready");
-      }
 
       const result = runBackground
         ? await this.executeActionInBackground(message)

--- a/src/types/background-workflow.ts
+++ b/src/types/background-workflow.ts
@@ -21,7 +21,6 @@ export enum WorkflowCommandType {
   CLEANUP_WORKFLOW_TRIGGERS = "CLEANUP_WORKFLOW_TRIGGERS",
   TRIGGER_FIRED = "TRIGGER_FIRED",
   CLEAN_HTTP_TRIGGERS = "CLEAN_HTTP_TRIGGERS",
-  CHECK_READINESS = "CHECK_READINESS",
 }
 
 // Command system for content scripts
@@ -71,16 +70,6 @@ export interface StatusMessage {
   error?: string;
   outputHandle?: string;
   config?: Record<string, any>;
-}
-
-export interface ReadinessCheckCommand {
-  type: WorkflowCommandType.CHECK_READINESS;
-  tabId: number;
-}
-
-export interface ReadinessResponse {
-  ready: boolean;
-  data?: any;
 }
 
 export interface HttpTriggerRegistration {

--- a/src/types/background-workflow.ts
+++ b/src/types/background-workflow.ts
@@ -18,6 +18,7 @@ export enum WorkflowCommandType {
   EXECUTE_ACTION = "EXECUTE_ACTION",
   INIT_TRIGGER = "INIT_TRIGGER",
   CLEANUP_TRIGGERS = "CLEANUP_TRIGGERS",
+  CLEANUP_WORKFLOW_TRIGGERS = "CLEANUP_WORKFLOW_TRIGGERS",
   TRIGGER_FIRED = "TRIGGER_FIRED",
   CLEAN_HTTP_TRIGGERS = "CLEAN_HTTP_TRIGGERS",
   CHECK_READINESS = "CHECK_READINESS",
@@ -40,6 +41,11 @@ export interface ActionCommand extends WorkflowCommand {
 
 export interface TriggerCommand extends WorkflowCommand {
   type: WorkflowCommandType.INIT_TRIGGER;
+}
+
+export interface CleanupWorkflowTriggersCommand {
+  type: WorkflowCommandType.CLEANUP_WORKFLOW_TRIGGERS;
+  workflowIds: string[];
 }
 
 export interface TriggerFiredCommand {

--- a/src/types/triggers.ts
+++ b/src/types/triggers.ts
@@ -18,6 +18,8 @@ export interface TriggerSetupResult {
   cleanup?: () => void; // Function to clean up resources (observers, timeouts, etc.)
 }
 
+export type TriggerCleanup = () => void | Promise<void>;
+
 // Abstract base class for all triggers
 export abstract class BaseTrigger<
   TConfig = Record<string, any>,
@@ -41,7 +43,7 @@ export abstract class BaseTrigger<
     workflowId: string,
     nodeId: string,
     onTrigger: (data?: TOutput) => Promise<void>,
-  ): Promise<void>;
+  ): Promise<TriggerCleanup | void>;
 
   // Clean up any resources (event listeners, observers, timeouts) created during setup
   async cleanup(): Promise<void> {}

--- a/tests/workflow-registration.spec.ts
+++ b/tests/workflow-registration.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "./test.base";
+import { DEMO_BUTTON_WORKFLOW } from "./demoWorkflows/button";
+import { DEMO_WORKFLOW } from "./demoWorkflows/index";
+import { seedWorkflows } from "./utils";
+
+test.describe("Workflow registration and cleanup", () => {
+  test("runs a page-load workflow once for a page load", async ({
+    page,
+    baseUrl,
+  }) => {
+    await seedWorkflows(baseUrl, page, [DEMO_WORKFLOW]);
+
+    await page.goto("https://example.com");
+
+    await expect(page.getByText("Hello from Houdin workflow")).toBeVisible();
+    await expect(page.getByText("Hello from Houdin workflow")).toHaveCount(1);
+  });
+
+  test("does not duplicate registered triggers after back and forward", async ({
+    page,
+    baseUrl,
+  }) => {
+    await seedWorkflows(baseUrl, page, [DEMO_BUTTON_WORKFLOW]);
+
+    await page.goto("https://example.com");
+    await expect(page.getByText("FB")).toHaveCount(1);
+
+    await page.evaluate(() => window.history.pushState({}, "", "/next"));
+    await page.waitForURL("https://example.com/next");
+    await expect(page.getByText("FB")).toHaveCount(1);
+
+    await page.goBack();
+    await page.waitForURL("https://example.com/");
+    await expect(page.getByText("FB")).toHaveCount(1);
+
+    await page.goForward();
+    await page.waitForURL("https://example.com/next");
+    await expect(page.getByText("FB")).toHaveCount(1);
+  });
+
+  test("cleans up triggers when the URL no longer matches", async ({
+    page,
+    baseUrl,
+  }) => {
+    await seedWorkflows(baseUrl, page, [
+      {
+        ...DEMO_BUTTON_WORKFLOW,
+        urlPattern: "https://example.com/active*",
+      },
+    ]);
+
+    await page.goto("https://example.com/active");
+    await expect(page.getByText("FB")).toHaveCount(1);
+
+    await page.evaluate(() => window.history.pushState({}, "", "/inactive"));
+    await page.waitForURL("https://example.com/inactive");
+
+    await expect(page.getByText("FB")).toHaveCount(0);
+  });
+
+  test("registers workflows when SPA navigation reaches a target URL", async ({
+    page,
+    baseUrl,
+  }) => {
+    await seedWorkflows(baseUrl, page, [
+      {
+        ...DEMO_WORKFLOW,
+        urlPattern: "https://example.com/target*",
+      },
+    ]);
+
+    await page.goto("https://example.com/start");
+    await expect(page.getByText("Hello from Houdin workflow")).toHaveCount(0);
+
+    await page.evaluate(() => window.history.pushState({}, "", "/target"));
+    await page.waitForURL("https://example.com/target");
+
+    await expect(page.getByText("Hello from Houdin workflow")).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.getByText("Hello from Houdin workflow")).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
## Changes

### Fixes
- Fixed SPA navigation trigger reliability by having background drive URL changes via `webNavigation` API
- Fixed button trigger disappearing on back/forward navigation by adding self-healing reinjection
- Fixed content-script connection races with automatic retry on receiving-end errors

### Refactoring
- Removed content-script readiness handshake (`CHECK_READINESS`) — content script is now always injected and initialized
- Simplified content script startup from minimal/full split to single initialization path
- Removed `ensureInitialized()` from injector since content script is always present
- Simplified page-load trigger by removing `firedUrls` tracking
- Extracted and normalized HTTP trigger callback in background message handler

### Architecture
- Background now owns all navigation detection (`onCompleted`, `onHistoryStateUpdated`)
- Content script focuses on trigger execution and action handling only
- Injector now self-heals `mantine-injector-root` if removed by page DOM changes

## Context

Previously, the background script would clear tab state aggressively on SPA navigations, which could kill in-flight executors and cause triggers to miss. The content script also had a complex minimal/full initialization split that could race with background messages.

This change simplifies the model: the content script is always present and initialized, while the background manages workflow lifecycle around navigation events. Triggers that inject DOM elements now observe and repair themselves when the host page replaces their target nodes.